### PR TITLE
Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Setting up and running BrowserBoxPro with Docker is straightforward with the fol
 
 ```console
 PORT=8080 # or select your preferred port
-bash <(curl -s https://raw.githubusercontent.com/dosyago/BrowserBoxPro/ade4d56879863a710b37ea9f0309fcc6c3166d10/deploy-scripts/run_docker.sh) $PORT
+bash <(curl -s https://raw.githubusercontent.com/dosyago/BrowserBoxPro/453fdd5afcffd9ae517435a3df3e71ce7f80f94d/deploy-scripts/run_docker.sh) $PORT
 ```
 
 Voila! BrowserBoxPro should be operational on your machine. Should you encounter any issues, we're here to help at sales@dosyago.com. To purchase licenses, head over to our website: https://dosaygo.com.

--- a/deploy-scripts/run_docker.sh
+++ b/deploy-scripts/run_docker.sh
@@ -35,6 +35,10 @@ print_instructions() {
 # Check if certificate and key files exist
 if [ -d "$certDir" ]; then
     if [ -f "$certFile" ] && [ -f "$keyFile" ]; then
+        # the read permission is so the key file can be used by the application
+        # inside the container
+        # otherwise HTTPS won't work and that breaks the app
+        chmod 644 $certDir/*.pem
         echo "Great job! Your SSL/TLS/HTTPS certificates are all set up correctly. You're ready to go!"
     else
         echo "Almost there! Your 'sslcerts' directory exists, but it seems you're missing some certificate files."


### PR DESCRIPTION
Fix a permissions issue so that the user in the docker container can read your sslcerts when you mount them to server the application from docker from your server. Otherwise the app can't read the mounted certs and HTTPS fails, which breaks the app (and security)